### PR TITLE
Fix comment for register addresses in syscon

### DIFF
--- a/rtl/veerwolf_syscon.v
+++ b/rtl/veerwolf_syscon.v
@@ -192,7 +192,7 @@ module veerwolf_syscon
 	     if (i_wb_sel[2]) mtimecmp[55:48] <= i_wb_dat[23:16];
 	     if (i_wb_sel[3]) mtimecmp[63:56] <= i_wb_dat[31:24];
 	  end
-	  12 : begin //0x30-3f
+	  12 : begin //0x30-33
 	     if (i_wb_sel[0]) irq_timer_cnt[7:0]   <= i_wb_dat[7:0]  ;
 	     if (i_wb_sel[1]) irq_timer_cnt[15:8]  <= i_wb_dat[15:8] ;
 	     if (i_wb_sel[2]) irq_timer_cnt[23:16] <= i_wb_dat[23:16];


### PR DESCRIPTION
I'm pretty sure this should be 0x33, not 0x3F.