### PR TITLE
Add target for an Intel Agilex 5 premium devkit.

### DIFF
--- a/data/agilex5.sdc
+++ b/data/agilex5.sdc
@@ -1,0 +1,7 @@
+create_clock -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports {clk}];
+
+# main system clock (25 Mhz)
+create_generated_clock -name "clk25MHz" -multiply_by 8 -divide_by 32 -source [get_ports {clk}] [get_nets {clk_gen|o_clk_pll}]
+
+# JTAG clock (10 MHz)
+create_clock -name tck_dmi -period 100.00 [get_ports i_jtag_tck];

--- a/data/agilex5.tcl
+++ b/data/agilex5.tcl
@@ -1,0 +1,133 @@
+set_global_assignment -name VERILOG_CU_MODE MFCU
+set_global_assignment -name OPTIMIZATION_MODE "AGGRESSIVE AREA"
+*
+set_global_assignment -name ERROR_CHECK_FREQUENCY_DIVISOR 256
+set_global_assignment -name EDA_SIMULATION_TOOL "Questa Intel FPGA (Verilog)"
+set_global_assignment -name EDA_TIME_SCALE "1 ps" -section_id eda_simulation
+set_global_assignment -name EDA_OUTPUT_DATA_FORMAT "VERILOG HDL" -section_id eda_simulation
+
+set_global_assignment -name GENERATE_COMPRESSED_SOF ON
+set_global_assignment -name AUTO_RESTART_CONFIGURATION OFF
+set_global_assignment -name STRATIXV_CONFIGURATION_SCHEME "AVST X8"
+set_global_assignment -name ON_CHIP_BITSTREAM_DECOMPRESSION OFF
+set_global_assignment -name USE_CONF_DONE SDM_IO12
+set_global_assignment -name USE_HPS_COLD_RESET SDM_IO7
+set_global_assignment -name DEVICE_INITIALIZATION_CLOCK OSC_CLK_1_125MHZ
+set_global_assignment -name POWER_APPLY_THERMAL_MARGIN ADDITIONAL
+
+set_global_assignment -name ERROR_ON_WARNINGS_PARSING_SDC_ON_RTL_CONSTRAINTS ON
+set_global_assignment -name ERROR_ON_WARNINGS_LOADING_SDC_ON_RTL_CONSTRAINTS ON
+set_global_assignment -name RTL_SDC_FILE src/veerwolf_0.7.5/data/agilex5.sdc
+
+# Clock
+set_location_assignment PIN_D8 -to clk -comment IOBANK_6C
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to clk -entity veerwolf_agilex
+
+# Reset
+set_location_assignment PIN_BK118 -to rstn -comment IOBANK_5B
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to rstn -entity veerwolf_agilex
+
+# UART RX
+set_location_assignment PIN_CJ2 -to i_uart_rx -comment IOBANK_6B
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_uart_rx -entity veerwolf_agilex
+
+# UART TX
+set_location_assignment PIN_CK4 -to o_uart_tx -comment IOBANK_6B
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to o_uart_rx -entity veerwolf_agilex
+
+# SPI Flash
+set_location_assignment PIN_BU28 -to o_flash_cs_n -comment IOBANK_6A
+set_location_assignment PIN_BP31 -to o_flash_mosi -comment IOBANK_6A
+set_location_assignment PIN_BR28 -to i_flash_miso -comment IOBANK_6A
+set_location_assignment PIN_BR31 -to o_flash_sclk -comment IOBANK_6A
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to o_flash_cs_n -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to o_flash_mosi -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_flash_miso -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to o_flash_sclk -entity veerwolf_agilex
+
+# JTAG
+set_location_assignment PIN_BU31 -to i_jtag_tck -comment IOBANK_6A
+set_location_assignment PIN_BM28 -to i_jtag_tms -comment IOBANK_6A
+set_location_assignment PIN_BF21 -to i_jtag_tdi -comment IOBANK_6B
+set_location_assignment PIN_BM31 -to o_jtag_tdo -comment IOBANK_6A
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_jtag_tck -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_jtag_tms -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_jtag_tdi -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to o_jtag_tdo -entity veerwolf_agilex
+
+# GPIO (inputs)
+# User PB Bank 6A 3.3V
+set_location_assignment PIN_BK31 -to i_sw[0] -comment IOBANK_6A
+set_location_assignment PIN_BP22 -to i_sw[1] -comment IOBANK_6A
+set_location_assignment PIN_BK28 -to i_sw[2] -comment IOBANK_6A
+set_location_assignment PIN_BR22 -to i_sw[3] -comment IOBANK_6A
+# User SW Bank 6A 3.3V
+set_location_assignment PIN_CH12 -to i_sw[4] -comment IOBANK_6A
+set_location_assignment PIN_BU22 -to i_sw[5] -comment IOBANK_6A
+set_location_assignment PIN_BW19 -to i_sw[6] -comment IOBANK_6A
+set_location_assignment PIN_BH28 -to i_sw[7] -comment IOBANK_6A
+set_location_assignment PIN_BE93 -to i_sw[8] -comment IOBANK_2A_T
+set_location_assignment PIN_BE79 -to i_sw[9] -comment IOBANK_2A_T
+set_location_assignment PIN_BF83 -to i_sw[10] -comment IOBANK_2A_T
+set_location_assignment PIN_BE83 -to i_sw[11] -comment IOBANK_2A_T
+set_location_assignment PIN_CD134 -to i_sw[12] -comment IOBANK_5A
+set_location_assignment PIN_CD135 -to i_sw[13] -comment IOBANK_5A
+set_location_assignment PIN_CG134 -to i_sw[14] -comment IOBANK_5A
+set_location_assignment PIN_CH132 -to i_sw[15] -comment IOBANK_5A
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[0] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[1] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[2] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[3] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[4] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[5] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[6] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[7] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[8] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[9] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[10] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[11] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[12] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[13] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[14] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[15] -entity veerwolf_agilex
+
+
+# GPIO (outputs)
+# User LED Bank 2AT 1.1V
+set_location_assignment PIN_BM59 -to o_led[0] -comment IOBANK_2A_T
+set_location_assignment PIN_BH59 -to o_led[1] -comment IOBANK_2A_T
+set_location_assignment PIN_BH62 -to o_led[2] -comment IOBANK_2A_T
+set_location_assignment PIN_BK59 -to o_led[3] -comment IOBANK_2A_T
+# Bank 3BB 1.2V
+set_location_assignment PIN_D74 -to o_led[4] -comment IOBANK_3B_B
+set_location_assignment PIN_F74 -to o_led[5] -comment IOBANK_3B_B
+set_location_assignment PIN_F65 -to o_led[6] -comment IOBANK_3B_B
+set_location_assignment PIN_D65 -to o_led[7] -comment IOBANK_3B_B
+set_location_assignment PIN_K77 -to o_led[8] -comment IOBANK_3B_B
+set_location_assignment PIN_M77 -to o_led[9] -comment IOBANK_3B_B
+set_location_assignment PIN_F77 -to o_led[10] -comment IOBANK_3B_B
+set_location_assignment PIN_H77 -to o_led[11] -comment IOBANK_3B_B
+set_location_assignment PIN_M67 -to o_led[12] -comment IOBANK_3B_B
+set_location_assignment PIN_K67 -to o_led[13] -comment IOBANK_3B_B
+set_location_assignment PIN_H67 -to o_led[14] -comment IOBANK_3B_B
+set_location_assignment PIN_F67 -to o_led[15] -comment IOBANK_3B_B
+
+set_instance_assignment -name IO_STANDARD "1.1-V" -to o_led[0] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to o_led[1] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to o_led[2] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to o_led[3] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[8] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[8] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[8] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[8] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[8] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[9] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[10] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[11] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[12] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[13] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[14] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.2-V" -to o_led[15] -entity veerwolf_agilex

--- a/data/agilex5.tcl
+++ b/data/agilex5.tcl
@@ -23,8 +23,8 @@ set_global_assignment -name RTL_SDC_FILE src/veerwolf_0.7.5/data/agilex5.sdc
 set_location_assignment PIN_D8 -to clk -comment IOBANK_6C
 set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to clk -entity veerwolf_agilex
 
-# Reset
-set_location_assignment PIN_BK118 -to rstn -comment IOBANK_5B
+# Reset PB SW11 HPS_COLD_RESETn Bank 5B 3.3V
+set_location_assignment PIN_BM109 -to rstn -comment IOBANK_5B
 set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to rstn -entity veerwolf_agilex
 
 # UART RX
@@ -33,9 +33,9 @@ set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_uart_rx -entity v
 
 # UART TX
 set_location_assignment PIN_CK4 -to o_uart_tx -comment IOBANK_6B
-set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to o_uart_rx -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to o_uart_tx -entity veerwolf_agilex
 
-# SPI Flash
+# SPI Flash J9 FPGA USER IO 1-4 Bank 6A 3.3V
 set_location_assignment PIN_BU28 -to o_flash_cs_n -comment IOBANK_6A
 set_location_assignment PIN_BP31 -to o_flash_mosi -comment IOBANK_6A
 set_location_assignment PIN_BR28 -to i_flash_miso -comment IOBANK_6A
@@ -46,7 +46,7 @@ set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to o_flash_mosi -entit
 set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_flash_miso -entity veerwolf_agilex
 set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to o_flash_sclk -entity veerwolf_agilex
 
-# JTAG
+# JTAG J9 FPGA USER IO 5-7 Bank 6 3.3V
 set_location_assignment PIN_BU31 -to i_jtag_tck -comment IOBANK_6A
 set_location_assignment PIN_BM28 -to i_jtag_tms -comment IOBANK_6A
 set_location_assignment PIN_BF21 -to i_jtag_tdi -comment IOBANK_6B
@@ -68,14 +68,16 @@ set_location_assignment PIN_CH12 -to i_sw[4] -comment IOBANK_6A
 set_location_assignment PIN_BU22 -to i_sw[5] -comment IOBANK_6A
 set_location_assignment PIN_BW19 -to i_sw[6] -comment IOBANK_6A
 set_location_assignment PIN_BH28 -to i_sw[7] -comment IOBANK_6A
-set_location_assignment PIN_BE93 -to i_sw[8] -comment IOBANK_2A_T
-set_location_assignment PIN_BE79 -to i_sw[9] -comment IOBANK_2A_T
-set_location_assignment PIN_BF83 -to i_sw[10] -comment IOBANK_2A_T
-set_location_assignment PIN_BE83 -to i_sw[11] -comment IOBANK_2A_T
-set_location_assignment PIN_CD134 -to i_sw[12] -comment IOBANK_5A
-set_location_assignment PIN_CD135 -to i_sw[13] -comment IOBANK_5A
-set_location_assignment PIN_CG134 -to i_sw[14] -comment IOBANK_5A
-set_location_assignment PIN_CH132 -to i_sw[15] -comment IOBANK_5A
+# MAX SPARE Bank 5A 3.3V
+set_location_assignment PIN_CD134 -to i_sw[8] -comment IOBANK_5A
+set_location_assignment PIN_CD135 -to i_sw[9] -comment IOBANK_5A
+set_location_assignment PIN_CG134 -to i_sw[10] -comment IOBANK_5A
+set_location_assignment PIN_CH132 -to i_sw[11] -comment IOBANK_5A
+# HSIO SW24 Bank 2AT 1.1V
+set_location_assignment PIN_BE93 -to i_sw[12] -comment IOBANK_2A_T
+set_location_assignment PIN_BE79 -to i_sw[13] -comment IOBANK_2A_T
+set_location_assignment PIN_BF83 -to i_sw[14] -comment IOBANK_2A_T
+set_location_assignment PIN_BE83 -to i_sw[15] -comment IOBANK_2A_T
 
 set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[0] -entity veerwolf_agilex
 set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[1] -entity veerwolf_agilex
@@ -85,14 +87,14 @@ set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[4] -entity vee
 set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[5] -entity veerwolf_agilex
 set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[6] -entity veerwolf_agilex
 set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[7] -entity veerwolf_agilex
-set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[8] -entity veerwolf_agilex
-set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[9] -entity veerwolf_agilex
-set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[10] -entity veerwolf_agilex
-set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[11] -entity veerwolf_agilex
-set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[12] -entity veerwolf_agilex
-set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[13] -entity veerwolf_agilex
-set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[14] -entity veerwolf_agilex
-set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[15] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[8] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[9] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[10] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_sw[11] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[12] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[13] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[14] -entity veerwolf_agilex
+set_instance_assignment -name IO_STANDARD "1.1-V" -to i_sw[15] -entity veerwolf_agilex
 
 
 # GPIO (outputs)
@@ -101,19 +103,19 @@ set_location_assignment PIN_BM59 -to o_led[0] -comment IOBANK_2A_T
 set_location_assignment PIN_BH59 -to o_led[1] -comment IOBANK_2A_T
 set_location_assignment PIN_BH62 -to o_led[2] -comment IOBANK_2A_T
 set_location_assignment PIN_BK59 -to o_led[3] -comment IOBANK_2A_T
-# Bank 3BB 1.2V
-set_location_assignment PIN_D74 -to o_led[4] -comment IOBANK_3B_B
-set_location_assignment PIN_F74 -to o_led[5] -comment IOBANK_3B_B
-set_location_assignment PIN_F65 -to o_led[6] -comment IOBANK_3B_B
-set_location_assignment PIN_D65 -to o_led[7] -comment IOBANK_3B_B
-set_location_assignment PIN_K77 -to o_led[8] -comment IOBANK_3B_B
-set_location_assignment PIN_M77 -to o_led[9] -comment IOBANK_3B_B
-set_location_assignment PIN_F77 -to o_led[10] -comment IOBANK_3B_B
-set_location_assignment PIN_H77 -to o_led[11] -comment IOBANK_3B_B
-set_location_assignment PIN_M67 -to o_led[12] -comment IOBANK_3B_B
-set_location_assignment PIN_K67 -to o_led[13] -comment IOBANK_3B_B
-set_location_assignment PIN_H67 -to o_led[14] -comment IOBANK_3B_B
-set_location_assignment PIN_F67 -to o_led[15] -comment IOBANK_3B_B
+# FMC LA Bank 3BT 1.2V
+set_location_assignment PIN_B42 -to o_led[4] -comment IOBANK_3B_B
+set_location_assignment PIN_A45 -to o_led[5] -comment IOBANK_3B_B
+set_location_assignment PIN_A48 -to o_led[6] -comment IOBANK_3B_B
+set_location_assignment PIN_B45 -to o_led[7] -comment IOBANK_3B_B
+set_location_assignment PIN_A51 -to o_led[8] -comment IOBANK_3B_B
+set_location_assignment PIN_B51 -to o_led[9] -comment IOBANK_3B_B
+set_location_assignment PIN_B54 -to o_led[10] -comment IOBANK_3B_B
+set_location_assignment PIN_A54 -to o_led[11] -comment IOBANK_3B_B
+set_location_assignment PIN_B60 -to o_led[12] -comment IOBANK_3B_B
+set_location_assignment PIN_A63 -to o_led[13] -comment IOBANK_3B_B
+set_location_assignment PIN_A60 -to o_led[14] -comment IOBANK_3B_B
+set_location_assignment PIN_B56 -to o_led[15] -comment IOBANK_3B_B
 
 set_instance_assignment -name IO_STANDARD "1.1-V" -to o_led[0] -entity veerwolf_agilex
 set_instance_assignment -name IO_STANDARD "1.1-V" -to o_led[1] -entity veerwolf_agilex

--- a/rtl/clk_gen_agilex.v
+++ b/rtl/clk_gen_agilex.v
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2019 Western Digital Corporation or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//********************************************************************************
+// $Id$
+//
+// Function: VeeRwolf Altera Agilex clock generation
+// Comments:
+//
+//********************************************************************************
+
+module clk_gen_agilex
+  (input  wire    i_clk,
+   input  wire    i_rst,
+   output wire    o_clk_core,
+   output wire    o_rst_core);
+
+   parameter CPU_TYPE = "";
+
+   wire   o_clk_pll;
+   wire   locked;
+   wire   ninit_done;
+   reg    rst_reg1;
+   reg    rst_reg2;
+
+   assign o_rst_core = rst_reg2;
+   assign o_clk_core = o_clk_pll;
+
+   // ================================================================
+   // Synchronize Reset
+   // ================================================================
+   always @(posedge o_clk_pll) begin
+    if (!locked || i_rst) begin
+      rst_reg1 <= 1'b1;
+      rst_reg2 <= 1'b1;
+    end else begin
+      rst_reg1 <= 1'b0;
+      rst_reg2 <= rst_reg1;
+    end
+   end
+
+  // ================================================================
+  // Agilex Reset Release
+  // ================================================================
+	altera_agilex_config_reset_release_endpoint config_reset_release_endpoint(
+		.conf_reset(ninit_done)
+	);
+
+   ipm_iopll_basic #(
+      .REFERENCE_CLOCK_FREQUENCY ("100.0 MHz"),
+      .N_CNT                     (1), // divide factor of N-counter
+      .M_CNT                     (8), // multiply factor of M-counter
+      .C0_CNT                    ((CPU_TYPE == "EL2") ? 32 : 16), // divide factor for the output clock 
+      .C1_CNT                    (1),
+      .C2_CNT                    (1),
+      .C3_CNT                    (1),
+      .C4_CNT                    (1),
+      .C5_CNT                    (1),
+      .C6_CNT                    (1),
+      .PLL_SIM_MODEL             ("")
+   ) my_pll (
+    .refclk    (i_clk),           //input, width = 1
+    .reset     (ninit_done),      //input, width = 1
+    .outclk0   (o_clk_pll),             //output, width = 1
+    .outclk1   (),                //output, width = 1
+    .outclk2   (),                //output, width = 1
+    .outclk3   (),                //output, width = 1
+    .outclk4   (),                //output, width = 1
+    .outclk5   (),                //output, width = 1
+    .outclk6   (),                //output, width = 1
+    .locked    (locked)           //output, width = 1
+   );
+endmodule

--- a/rtl/veerwolf_agilex.v
+++ b/rtl/veerwolf_agilex.v
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2019 Western Digital Corporation or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//********************************************************************************
+// $Id$
+//
+// Function: VeeRwolf toplevel for Agilex 5 premium devkit
+// Comments:
+//
+//********************************************************************************
+
+`default_nettype none
+`include "common_defines.vh"
+
+module veerwolf_agilex
+  #(parameter bootrom_file = "",
+    parameter cpu_type = "EH1")
+   (input wire 	       clk,
+    input wire 	       rstn,
+    input wire 	      i_jtag_tck,
+    input wire 	      i_jtag_tms,
+    input wire 	      i_jtag_tdi,
+    output wire 	    o_jtag_tdo,
+    output wire        o_flash_sclk,
+    output wire        o_flash_cs_n,
+    output wire        o_flash_mosi,
+    input wire 	       i_flash_miso,
+    input wire 	       i_uart_rx,
+    output wire        o_uart_tx,
+    input wire [15:0]  i_sw,
+    output reg [15:0]  o_led);
+
+   wire [63:0] 	       gpio_out;
+   reg [15:0] 	       led_int_r;
+
+   reg [15:0] 	       sw_r;
+   reg [15:0] 	       sw_2r;
+
+
+  localparam RAM_SIZE     = 32'h10000;
+  reg [1023:0] ram_init_file;
+
+  reg [1023:0] rom_init_file;
+
+  wire 	 clk_core;
+  wire 	 rst_core;
+
+  clk_gen_agilex
+    #(.CPU_TYPE (cpu_type))
+  clk_gen
+    (.i_clk (clk),
+     .i_rst (~rstn),
+     .o_clk_core (clk_core),
+     .o_rst_core (rst_core));
+
+  wire [5:0]  ram_awid;
+  wire [31:0] ram_awaddr;
+  wire [7:0]  ram_awlen;
+  wire [2:0]  ram_awsize;
+  wire [1:0]  ram_awburst;
+  wire        ram_awlock;
+  wire [3:0]  ram_awcache;
+  wire [2:0]  ram_awprot;
+  wire [3:0]  ram_awregion;
+  wire [3:0]  ram_awqos;
+  wire        ram_awvalid;
+  wire        ram_awready;
+  wire [5:0]  ram_arid;
+  wire [31:0] ram_araddr;
+  wire [7:0]  ram_arlen;
+  wire [2:0]  ram_arsize;
+  wire [1:0]  ram_arburst;
+  wire        ram_arlock;
+  wire [3:0]  ram_arcache;
+  wire [2:0]  ram_arprot;
+  wire [3:0]  ram_arregion;
+  wire [3:0]  ram_arqos;
+  wire        ram_arvalid;
+  wire        ram_arready;
+  wire [63:0] ram_wdata;
+  wire [7:0]  ram_wstrb;
+  wire        ram_wlast;
+  wire        ram_wvalid;
+  wire        ram_wready;
+  wire [5:0]  ram_bid;
+  wire [1:0]  ram_bresp;
+  wire        ram_bvalid;
+  wire        ram_bready;
+  wire [5:0]  ram_rid;
+  wire [63:0] ram_rdata;
+  wire [1:0]  ram_rresp;
+  wire        ram_rlast;
+  wire        ram_rvalid;
+  wire        ram_rready;
+
+  wire        dmi_reg_en;
+  wire [6:0]  dmi_reg_addr;
+  wire        dmi_reg_wr_en;
+  wire [31:0] dmi_reg_wdata;
+  wire [31:0] dmi_reg_rdata;
+  wire        dmi_hard_reset;
+  
+  axi_ram
+    #(.DATA_WIDTH (64),
+      .ADDR_WIDTH ($clog2(RAM_SIZE)),
+      .ID_WIDTH  (6))
+  ram
+    (.clk       (clk_core),
+     .rst       (rst_core),
+     .s_axi_awid    (ram_awid),
+     .s_axi_awaddr  (ram_awaddr[$clog2(RAM_SIZE)-1:0]),
+     .s_axi_awlen   (ram_awlen),
+     .s_axi_awsize  (ram_awsize),
+     .s_axi_awburst (ram_awburst),
+     .s_axi_awlock  (1'd0),
+     .s_axi_awcache (4'd0),
+     .s_axi_awprot  (3'd0),
+     .s_axi_awvalid (ram_awvalid),
+     .s_axi_awready (ram_awready),
+     .s_axi_arid    (ram_arid),
+     .s_axi_araddr  (ram_araddr[$clog2(RAM_SIZE)-1:0]),
+     .s_axi_arlen   (ram_arlen),
+     .s_axi_arsize  (ram_arsize),
+     .s_axi_arburst (ram_arburst),
+     .s_axi_arlock  (1'd0),
+     .s_axi_arcache (4'd0),
+     .s_axi_arprot  (3'd0),
+     .s_axi_arvalid (ram_arvalid),
+     .s_axi_arready (ram_arready),
+     .s_axi_wdata  (ram_wdata),
+     .s_axi_wstrb  (ram_wstrb),
+     .s_axi_wlast  (ram_wlast),
+     .s_axi_wvalid (ram_wvalid),
+     .s_axi_wready (ram_wready),
+     .s_axi_bid    (ram_bid),
+     .s_axi_bresp  (ram_bresp),
+     .s_axi_bvalid (ram_bvalid),
+     .s_axi_bready (ram_bready),
+     .s_axi_rid    (ram_rid),
+     .s_axi_rdata  (ram_rdata),
+     .s_axi_rresp  (ram_rresp),
+     .s_axi_rlast  (ram_rlast),
+     .s_axi_rvalid (ram_rvalid),
+     .s_axi_rready (ram_rready));
+    
+
+  dmi_wrapper dmi_wrapper
+    (.trst_n    (~rst_core),
+     .tck       (i_jtag_tck),
+     .tms       (i_jtag_tms),
+     .tdi       (i_jtag_tdi),
+     .tdo       (o_jtag_tdo),
+     .tdoEnable (),
+     // Processor Signals
+     .core_rst_n     (~rst_core),
+     .core_clk       (clk_core),
+     .jtag_id        (31'd0),
+     .rd_data        (dmi_reg_rdata),
+     .reg_wr_data    (dmi_reg_wdata),
+     .reg_wr_addr    (dmi_reg_addr),
+     .reg_en         (dmi_reg_en),
+     .reg_wr_en      (dmi_reg_wr_en),
+     .dmi_hard_reset (dmi_hard_reset)); 
+
+
+  veerwolf_core
+    #(.bootrom_file (bootrom_file),
+      .clk_freq_hz  ((cpu_type == "EL2") ? 32'd25_000_000 : 32'd50_000_000))
+   veerwolf
+    (.clk  (clk_core),
+     .rstn (~rst_core),
+     .dmi_reg_rdata       (dmi_reg_rdata),
+     .dmi_reg_wdata       (dmi_reg_wdata),
+     .dmi_reg_addr        (dmi_reg_addr),
+     .dmi_reg_en          (dmi_reg_en),
+     .dmi_reg_wr_en       (dmi_reg_wr_en),
+     .dmi_hard_reset      (dmi_hard_reset),
+     .o_flash_sclk        (o_flash_sclk),
+     .o_flash_cs_n        (o_flash_cs_n),
+     .o_flash_mosi        (o_flash_mosi),
+     .i_flash_miso        (i_flash_miso),
+     .i_uart_rx           (i_uart_rx),
+     .o_uart_tx           (o_uart_tx),
+     .o_ram_awid          (ram_awid),
+     .o_ram_awaddr        (ram_awaddr),
+     .o_ram_awlen         (ram_awlen),
+     .o_ram_awsize        (ram_awsize),
+     .o_ram_awburst       (ram_awburst),
+     .o_ram_awlock        (ram_awlock),
+     .o_ram_awcache       (ram_awcache),
+     .o_ram_awprot        (ram_awprot),
+     .o_ram_awregion      (ram_awregion),
+     .o_ram_awqos         (ram_awqos),
+     .o_ram_awvalid       (ram_awvalid),
+     .i_ram_awready       (ram_awready),
+     .o_ram_arid          (ram_arid),
+     .o_ram_araddr        (ram_araddr),
+     .o_ram_arlen         (ram_arlen),
+     .o_ram_arsize        (ram_arsize),
+     .o_ram_arburst       (ram_arburst),
+     .o_ram_arlock        (ram_arlock),
+     .o_ram_arcache       (ram_arcache),
+     .o_ram_arprot        (ram_arprot),
+     .o_ram_arregion      (ram_arregion),
+     .o_ram_arqos         (ram_arqos),
+     .o_ram_arvalid       (ram_arvalid),
+     .i_ram_arready       (ram_arready),
+     .o_ram_wdata         (ram_wdata),
+     .o_ram_wstrb         (ram_wstrb),
+     .o_ram_wlast         (ram_wlast),
+     .o_ram_wvalid        (ram_wvalid),
+     .i_ram_wready        (ram_wready),
+     .i_ram_bid           (ram_bid),
+     .i_ram_bresp         (ram_bresp),
+     .i_ram_bvalid        (ram_bvalid),
+     .o_ram_bready        (ram_bready),
+     .i_ram_rid           (ram_rid),
+     .i_ram_rdata         (ram_rdata),
+     .i_ram_rresp         (ram_rresp),
+     .i_ram_rlast         (ram_rlast),
+     .i_ram_rvalid        (ram_rvalid),
+     .o_ram_rready        (ram_rready),
+     .i_ram_init_done     (1'b1),
+     .i_ram_init_error    (1'b0),
+     .i_gpio           ({32'd0,16'd0,sw_2r}),
+     .o_gpio           (gpio_out));
+
+   always @(posedge clk_core) begin
+    o_led <= led_int_r;
+    led_int_r <= gpio_out[15:0];
+    sw_r <= i_sw;
+    sw_2r <= sw_r;
+   end
+
+endmodule

--- a/rtl/veerwolf_core.v
+++ b/rtl/veerwolf_core.v
@@ -145,9 +145,9 @@ module veerwolf_core
 
    wire [15:2] 		       wb_adr;
 
-   assign		       wb_m2s_io_adr = {16'd0,wb_adr,2'b00};
-   assign wb_m2s_io_cti = 3'b000;
-   assign wb_m2s_io_bte = 2'b00;
+   assign		       wb_io_adr = {16'd0,wb_adr,2'b00};
+   assign wb_io_cti = 3'b000;
+   assign wb_io_bte = 2'b00;
 
    axi2wb
      #(.AW (16),
@@ -157,14 +157,14 @@ module veerwolf_core
       .i_clk       (clk),
       .i_rst       (~rst_n),
       .o_wb_adr    (wb_adr),
-      .o_wb_dat    (wb_m2s_io_dat),
-      .o_wb_sel    (wb_m2s_io_sel),
-      .o_wb_we     (wb_m2s_io_we),
-      .o_wb_cyc    (wb_m2s_io_cyc),
-      .o_wb_stb    (wb_m2s_io_stb),
-      .i_wb_rdt    (wb_s2m_io_dat),
-      .i_wb_ack    (wb_s2m_io_ack),
-      .i_wb_err    (wb_s2m_io_err),
+      .o_wb_dat    (wb_io_dat),
+      .o_wb_sel    (wb_io_sel),
+      .o_wb_we     (wb_io_we),
+      .o_wb_cyc    (wb_io_cyc),
+      .o_wb_stb    (wb_io_stb),
+      .i_wb_rdt    (wb_io_rdt),
+      .i_wb_ack    (wb_io_ack),
+      .i_wb_err    (wb_io_err),
 
       .i_awaddr    (io_awaddr[15:0]),
       .i_awid      (io_awid),
@@ -199,17 +199,17 @@ module veerwolf_core
    bootrom
      (.i_clk    (wb_clk),
       .i_rst    (wb_rst),
-      .i_wb_adr (wb_m2s_rom_adr[$clog2(BOOTROM_SIZE)-1:2]),
-      .i_wb_dat (wb_m2s_rom_dat),
-      .i_wb_sel (wb_m2s_rom_sel),
-      .i_wb_we  (wb_m2s_rom_we),
-      .i_wb_cyc (wb_m2s_rom_cyc),
-      .i_wb_stb (wb_m2s_rom_stb),
-      .o_wb_rdt (wb_s2m_rom_dat),
-      .o_wb_ack (wb_s2m_rom_ack));
+      .i_wb_adr (wb_rom_adr[$clog2(BOOTROM_SIZE)-1:2]),
+      .i_wb_dat (wb_rom_dat),
+      .i_wb_sel (wb_rom_sel),
+      .i_wb_we  (wb_rom_we),
+      .i_wb_cyc (wb_rom_cyc),
+      .i_wb_stb (wb_rom_stb),
+      .o_wb_rdt (wb_rom_rdt),
+      .o_wb_ack (wb_rom_ack));
 
-   assign wb_s2m_rom_err = 1'b0;
-   assign wb_s2m_rom_rty = 1'b0;
+   assign wb_rom_err = 1'b0;
+   assign wb_rom_rty = 1'b0;
 
    veerwolf_syscon
      #(.clk_freq_hz (clk_freq_hz))
@@ -227,20 +227,20 @@ module veerwolf_core
       .o_nmi_vec        (nmi_vec),
       .o_nmi_int        (nmi_int),
 
-      .i_wb_adr         (wb_m2s_sys_adr[5:0]),
-      .i_wb_dat         (wb_m2s_sys_dat),
-      .i_wb_sel         (wb_m2s_sys_sel),
-      .i_wb_we          (wb_m2s_sys_we),
-      .i_wb_cyc         (wb_m2s_sys_cyc),
-      .i_wb_stb         (wb_m2s_sys_stb),
-      .o_wb_rdt         (wb_s2m_sys_dat),
-      .o_wb_ack         (wb_s2m_sys_ack));
+      .i_wb_adr         (wb_sys_adr[5:0]),
+      .i_wb_dat         (wb_sys_dat),
+      .i_wb_sel         (wb_sys_sel),
+      .i_wb_we          (wb_sys_we),
+      .i_wb_cyc         (wb_sys_cyc),
+      .i_wb_stb         (wb_sys_stb),
+      .o_wb_rdt         (wb_sys_rdt),
+      .o_wb_ack         (wb_sys_ack));
 
-   assign wb_s2m_sys_err = 1'b0;
-   assign wb_s2m_sys_rty = 1'b0;
+   assign wb_sys_err = 1'b0;
+   assign wb_sys_rty = 1'b0;
 
    wire [7:0] 		       spi_rdt;
-   assign wb_s2m_spi_flash_dat = {24'd0,spi_rdt};
+   assign wb_spi_flash_rdt = {24'd0,spi_rdt};
 
    simple_spi spi
      (// Wishbone slave interface
@@ -290,13 +290,13 @@ module veerwolf_core
 
        TODO: Make something sensible here instead
        */
-      .adr_i  (wb_m2s_spi_flash_adr[2] ? 3'd0 : wb_m2s_spi_flash_adr[5:3]),
-      .dat_i  (wb_m2s_spi_flash_dat[7:0]),
-      .we_i   (wb_m2s_spi_flash_we),
-      .cyc_i  (wb_m2s_spi_flash_cyc),
-      .stb_i  (wb_m2s_spi_flash_stb),
+      .adr_i  (wb_spi_flash_adr[2] ? 3'd0 : wb_spi_flash_adr[5:3]),
+      .dat_i  (wb_spi_flash_dat[7:0]),
+      .we_i   (wb_spi_flash_we),
+      .cyc_i  (wb_spi_flash_cyc),
+      .stb_i  (wb_spi_flash_stb),
       .dat_o  (spi_rdt),
-      .ack_o  (wb_s2m_spi_flash_ack),
+      .ack_o  (wb_spi_flash_ack),
       .inta_o (spi0_irq),
       // SPI interface
       .sck_o  (o_flash_sclk),
@@ -304,26 +304,26 @@ module veerwolf_core
       .mosi_o (o_flash_mosi),
       .miso_i (i_flash_miso));
 
-   assign wb_s2m_spi_flash_err = 1'b0;
-   assign wb_s2m_spi_flash_rty = 1'b0;
+   assign wb_spi_flash_err = 1'b0;
+   assign wb_spi_flash_rty = 1'b0;
 
    wire [7:0] 		       uart_rdt;
-   assign wb_s2m_uart_dat = {24'd0, uart_rdt};
-   assign wb_s2m_uart_err = 1'b0;
-   assign wb_s2m_uart_rty = 1'b0;
+   assign wb_uart_rdt = {24'd0, uart_rdt};
+   assign wb_uart_err = 1'b0;
+   assign wb_uart_rty = 1'b0;
 
    uart_top uart16550_0
      (// Wishbone slave interface
       .wb_clk_i	(clk),
       .wb_rst_i	(~rst_n),
-      .wb_adr_i	(wb_m2s_uart_adr[4:2]),
-      .wb_dat_i	(wb_m2s_uart_dat[7:0]),
-      .wb_we_i	(wb_m2s_uart_we),
-      .wb_cyc_i	(wb_m2s_uart_cyc),
-      .wb_stb_i	(wb_m2s_uart_stb),
+      .wb_adr_i	(wb_uart_adr[4:2]),
+      .wb_dat_i	(wb_uart_dat[7:0]),
+      .wb_we_i	(wb_uart_we),
+      .wb_cyc_i	(wb_uart_cyc),
+      .wb_stb_i	(wb_uart_stb),
       .wb_sel_i	(4'b0), // Not used in 8-bit mode
       .wb_dat_o	(uart_rdt),
-      .wb_ack_o	(wb_s2m_uart_ack),
+      .wb_ack_o	(wb_uart_ack),
 
       // Outputs
       .int_o     (uart_irq),

--- a/veerwolf.core
+++ b/veerwolf.core
@@ -25,7 +25,7 @@ filesets:
       - uart16550
       - ">=pulp-platform.org::axi:0.23.0-r1"
       - simple_spi
-      - wb_intercon
+      - ::wb_intercon:1.4.1
 
   bfm:
     files:
@@ -50,6 +50,14 @@ filesets:
       - tb/veerwolf_spi_tb.v
       - sw/hello.ubvh : {file_type : user, copyto : hello.ubvh}
     file_type : verilogSource
+
+  agilex5_files:
+    files :
+      - data/agilex5.sdc : {file_type : SDC}
+      - data/agilex5.tcl : {file_type : tclSource}
+      - rtl/clk_gen_agilex.v : {file_type : verilogSource}
+      - rtl/veerwolf_agilex.v    : {file_type : systemVerilogSource}
+      - rtl/axi_ram.v : {file_type : verilogSource}
 
   nexys_a7_files:
     files :
@@ -92,6 +100,23 @@ filesets:
       - sw/bootloader.vh : {file_type : user, copyto : bootloader.vh}
 
 targets:
+  agilex5:
+    default_tool : quartus
+    description : FPGA image with VeeR EH1 or EL2 for the Intel Agilex 5 FPGA E-Series DK A5E065BB32AES1 Premium devkit
+    filesets :
+      - "cpu_el2? (el2)"
+      - "!cpu_el2? (eh1)"
+      - bootrom
+      - core
+      - agilex5_files
+    generate : [intercon, "!cpu_el2? (veer_eh1_default_config)", "cpu_el2? (veer_el2_default_config)", version, wb_intercon]
+    parameters : [bootrom_file, "cpu_el2? (cpu_type=EL2)"]
+    tools:
+      quartus:
+        family : Agilex 5
+        device : A5ED065BB32AE6SR0
+    toplevel : veerwolf_agilex
+
   basys3:
     default_tool : vivado
     description : FPGA image with VeeR EL2 for the Digilent Basys 3 FPGA board


### PR DESCRIPTION
We have added support for the Intel Agilex 5 FPGA E-Series DK A5E065BB32AES1 Premium devkit. Please note that we have updated the dependencies with wb_intercon v1.4.1 and updated the relevant connections in the veerwolf_core.v RTL file.

We have tested that it compiles with Quartus Prime Pro 24.2 and that it runs on the hardware.